### PR TITLE
update retroarch-odroidgo2 package template to RetroArch 1.9.3

### DIFF
--- a/srcpkgs/retroarch-odroidgo2/patches/add_shutdown_reboot.patch
+++ b/srcpkgs/retroarch-odroidgo2/patches/add_shutdown_reboot.patch
@@ -1,8 +1,8 @@
 diff --git a/menu/menu_setting.c b/menu/menu_setting.c
-index 497bfedcfe..b4468699e9 100644
+index c10e7be251..e06b83d1dc 100644
 --- a/menu/menu_setting.c
 +++ b/menu/menu_setting.c
-@@ -8534,7 +8534,7 @@ static bool setting_append_list(
+@@ -8739,7 +8739,7 @@ static bool setting_append_list(
                parent_group);
  #endif
  
@@ -12,10 +12,10 @@ index 497bfedcfe..b4468699e9 100644
          CONFIG_ACTION(
                 list, list_info,
 diff --git a/retroarch.c b/retroarch.c
-index 1e75ff089c..c0d3c3467b 100644
+index 5d02fd8226..c68ccafcd4 100644
 --- a/retroarch.c
 +++ b/retroarch.c
-@@ -14368,7 +14368,7 @@ bool command_event(enum event_command cmd, void *data)
+@@ -14279,7 +14279,7 @@ bool command_event(enum event_command cmd, void *data)
           runloop_msg_queue_push(msg_hash_to_str(MSG_VALUE_SHUTTING_DOWN), 1, 180, true, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
           command_event(CMD_EVENT_MENU_SAVE_CURRENT_CONFIG, NULL);
           command_event(CMD_EVENT_QUIT, NULL);
@@ -24,7 +24,7 @@ index 1e75ff089c..c0d3c3467b 100644
  #endif
           break;
        case CMD_EVENT_REBOOT:
-@@ -14376,7 +14376,7 @@ bool command_event(enum event_command cmd, void *data)
+@@ -14287,7 +14287,7 @@ bool command_event(enum event_command cmd, void *data)
           runloop_msg_queue_push(msg_hash_to_str(MSG_VALUE_REBOOTING), 1, 180, true, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
           command_event(CMD_EVENT_MENU_SAVE_CURRENT_CONFIG, NULL);
           command_event(CMD_EVENT_QUIT, NULL);

--- a/srcpkgs/retroarch-odroidgo2/template
+++ b/srcpkgs/retroarch-odroidgo2/template
@@ -1,8 +1,8 @@
 # Template file for 'retroarch-odroidgo2'
 pkgname=retroarch-odroidgo2
-version=1.9.1
-revision=2
-_gitrev=222d4706daef21be3752e1a1b66033e840694765
+version=1.9.3
+revision=1
+_gitrev=d64769debceb2f549d64a17c8f288a8f4881187c
 wrksrc="RetroArch-${_gitrev}"
 build_style=configure
 configure_args="--prefix=/usr
@@ -36,7 +36,7 @@ short_desc="Official reference frontend for the libretro API"
 license="GPL-3.0-or-later"
 homepage="http://www.libretro.com/"
 distfiles="https://github.com/cplr/RetroArch/archive/${_gitrev}.tar.gz"
-checksum=8716d5516a32802b23d72d8f1a8de610837b6bacf2ffb1d5b138b2ccc4a1bc97
+checksum=ede8be89ded5dcb97dc483d84fe8b0b90b533f8a4a7912ab1a42d9b5eaef5cf3
 patch_args="-Np1"
 
 export CFLAGS="$CFLAGS -O3 -fno-tree-vectorize"


### PR DESCRIPTION
I have not tested the build for this yet (I just kicked off a build). Will update this PR when it's finished. Hopefully we can get this build added to the updated repo.